### PR TITLE
Add a condition on the duplicated event names

### DIFF
--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
@@ -423,6 +423,7 @@ public class SolidityFunctionWrapper extends Generator {
             throws ClassNotFoundException {
 
         Set<String> duplicateFunctionNames = getDuplicateFunctionNames(functionDefinitions);
+        changeEventsName(functionDefinitions);
         List<MethodSpec> methodSpecs = new ArrayList<>();
         for (AbiDefinition functionDefinition : functionDefinitions) {
             if (functionDefinition.getType().equals(TYPE_FUNCTION)) {
@@ -434,6 +435,25 @@ public class SolidityFunctionWrapper extends Generator {
             }
         }
         return methodSpecs;
+    }
+
+    private void changeEventsName(List<AbiDefinition> functionDefinitions) {
+
+        Map<String, Integer> countMap = new HashMap<>();
+
+        for (AbiDefinition functionDefinition : functionDefinitions) {
+            if (TYPE_EVENT.equals(functionDefinition.getType())
+                    && functionDefinition.getName() != null) {
+                String s = functionDefinition.getName();
+                if (countMap.containsKey(s)) {
+                    int count = countMap.get(s);
+                    functionDefinition.setName(s + count);
+                    countMap.put(s, count + 1);
+                } else {
+                    countMap.put(s, 1);
+                }
+            }
+        }
     }
 
     private List<TypeSpec> buildStructTypes(final List<AbiDefinition> functionDefinitions)
@@ -723,6 +743,7 @@ public class SolidityFunctionWrapper extends Generator {
         Set<String> fieldNames = new HashSet<>();
         fieldNames.add(Contract.FUNC_DEPLOY);
         Set<String> duplicateFunctionNames = getDuplicateFunctionNames(functionDefinitions);
+        changeEventsName(functionDefinitions);
         if (!duplicateFunctionNames.isEmpty()) {
             System.out.println(
                     "\nWarning: Duplicate field(s) found: "

--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -908,7 +908,9 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         AbiDefinition firstEventDefinition =
                 new AbiDefinition(
                         false,
-                        Arrays.asList(new NamedType("action", "string", false), new NamedType("pauseState", "bool", false)),
+                        Arrays.asList(
+                                new NamedType("action", "string", false),
+                                new NamedType("pauseState", "bool", false)),
                         "eventName",
                         Collections.emptyList(),
                         "event",
@@ -916,106 +918,113 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         AbiDefinition secondEventDefinition =
                 new AbiDefinition(
                         false,
-                        Arrays.asList(new NamedType("cToken", "address", false), new NamedType("action", "string", false), new NamedType("pauseState", "bool", false)),
+                        Arrays.asList(
+                                new NamedType("cToken", "address", false),
+                                new NamedType("action", "string", false),
+                                new NamedType("pauseState", "bool", false)),
                         "eventName",
                         Collections.emptyList(),
                         "event",
                         false);
         TypeSpec.Builder builder = TypeSpec.classBuilder("testClass");
-        builder.addMethods(solidityFunctionWrapper.buildFunctionDefinitions("testClass", builder, Arrays.asList(firstEventDefinition, secondEventDefinition)));
+        builder.addMethods(
+                solidityFunctionWrapper.buildFunctionDefinitions(
+                        "testClass",
+                        builder,
+                        Arrays.asList(firstEventDefinition, secondEventDefinition)));
 
         String expected =
-                "class testClass {\n" +
-                        "  public static final org.web3j.abi.datatypes.Event EVENTNAME_EVENT = new org.web3j.abi.datatypes.Event(\"eventName\", \n" +
-                        "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Utf8String>() {}, new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Bool>() {}));\n" +
-                        "  ;\n" +
-                        "\n" +
-                        "  public static final org.web3j.abi.datatypes.Event EVENTNAME1_EVENT = new org.web3j.abi.datatypes.Event(\"eventName1\", \n" +
-                        "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Address>() {}, new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Utf8String>() {}, new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Bool>() {}));\n" +
-                        "  ;\n" +
-                        "\n" +
-                        "  public static java.util.List<EventNameEventResponse> getEventNameEvents(org.web3j.protocol.core.methods.response.TransactionReceipt transactionReceipt) {\n" +
-                        "    java.util.List<org.web3j.tx.Contract.EventValuesWithLog> valueList = staticExtractEventParametersWithLog(EVENTNAME_EVENT, transactionReceipt);\n" +
-                        "    java.util.ArrayList<EventNameEventResponse> responses = new java.util.ArrayList<EventNameEventResponse>(valueList.size());\n" +
-                        "    for (org.web3j.tx.Contract.EventValuesWithLog eventValues : valueList) {\n" +
-                        "      EventNameEventResponse typedResponse = new EventNameEventResponse();\n" +
-                        "      typedResponse.log = eventValues.getLog();\n" +
-                        "      typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n" +
-                        "      typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(1).getValue();\n" +
-                        "      responses.add(typedResponse);\n" +
-                        "    }\n" +
-                        "    return responses;\n" +
-                        "  }\n" +
-                        "\n" +
-                        "  public io.reactivex.Flowable<EventNameEventResponse> eventNameEventFlowable(org.web3j.protocol.core.methods.request.EthFilter filter) {\n" +
-                        "    return web3j.ethLogFlowable(filter).map(new io.reactivex.functions.Function<org.web3j.protocol.core.methods.response.Log, EventNameEventResponse>() {\n" +
-                        "      @java.lang.Override\n" +
-                        "      public EventNameEventResponse apply(org.web3j.protocol.core.methods.response.Log log) {\n" +
-                        "        org.web3j.tx.Contract.EventValuesWithLog eventValues = extractEventParametersWithLog(EVENTNAME_EVENT, log);\n" +
-                        "        EventNameEventResponse typedResponse = new EventNameEventResponse();\n" +
-                        "        typedResponse.log = log;\n" +
-                        "        typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n" +
-                        "        typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(1).getValue();\n" +
-                        "        return typedResponse;\n" +
-                        "      }\n" +
-                        "    });\n" +
-                        "  }\n" +
-                        "\n" +
-                        "  public io.reactivex.Flowable<EventNameEventResponse> eventNameEventFlowable(org.web3j.protocol.core.DefaultBlockParameter startBlock, org.web3j.protocol.core.DefaultBlockParameter endBlock) {\n" +
-                        "    org.web3j.protocol.core.methods.request.EthFilter filter = new org.web3j.protocol.core.methods.request.EthFilter(startBlock, endBlock, getContractAddress());\n" +
-                        "    filter.addSingleTopic(org.web3j.abi.EventEncoder.encode(EVENTNAME_EVENT));\n" +
-                        "    return eventNameEventFlowable(filter);\n" +
-                        "  }\n" +
-                        "\n" +
-                        "  public static java.util.List<EventName1EventResponse> getEventName1Events(org.web3j.protocol.core.methods.response.TransactionReceipt transactionReceipt) {\n" +
-                        "    java.util.List<org.web3j.tx.Contract.EventValuesWithLog> valueList = staticExtractEventParametersWithLog(EVENTNAME1_EVENT, transactionReceipt);\n" +
-                        "    java.util.ArrayList<EventName1EventResponse> responses = new java.util.ArrayList<EventName1EventResponse>(valueList.size());\n" +
-                        "    for (org.web3j.tx.Contract.EventValuesWithLog eventValues : valueList) {\n" +
-                        "      EventName1EventResponse typedResponse = new EventName1EventResponse();\n" +
-                        "      typedResponse.log = eventValues.getLog();\n" +
-                        "      typedResponse.cToken = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n" +
-                        "      typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(1).getValue();\n" +
-                        "      typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(2).getValue();\n" +
-                        "      responses.add(typedResponse);\n" +
-                        "    }\n" +
-                        "    return responses;\n" +
-                        "  }\n" +
-                        "\n" +
-                        "  public io.reactivex.Flowable<EventName1EventResponse> eventName1EventFlowable(org.web3j.protocol.core.methods.request.EthFilter filter) {\n" +
-                        "    return web3j.ethLogFlowable(filter).map(new io.reactivex.functions.Function<org.web3j.protocol.core.methods.response.Log, EventName1EventResponse>() {\n" +
-                        "      @java.lang.Override\n" +
-                        "      public EventName1EventResponse apply(org.web3j.protocol.core.methods.response.Log log) {\n" +
-                        "        org.web3j.tx.Contract.EventValuesWithLog eventValues = extractEventParametersWithLog(EVENTNAME1_EVENT, log);\n" +
-                        "        EventName1EventResponse typedResponse = new EventName1EventResponse();\n" +
-                        "        typedResponse.log = log;\n" +
-                        "        typedResponse.cToken = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n" +
-                        "        typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(1).getValue();\n" +
-                        "        typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(2).getValue();\n" +
-                        "        return typedResponse;\n" +
-                        "      }\n" +
-                        "    });\n" +
-                        "  }\n" +
-                        "\n" +
-                        "  public io.reactivex.Flowable<EventName1EventResponse> eventName1EventFlowable(org.web3j.protocol.core.DefaultBlockParameter startBlock, org.web3j.protocol.core.DefaultBlockParameter endBlock) {\n" +
-                        "    org.web3j.protocol.core.methods.request.EthFilter filter = new org.web3j.protocol.core.methods.request.EthFilter(startBlock, endBlock, getContractAddress());\n" +
-                        "    filter.addSingleTopic(org.web3j.abi.EventEncoder.encode(EVENTNAME1_EVENT));\n" +
-                        "    return eventName1EventFlowable(filter);\n" +
-                        "  }\n" +
-                        "\n" +
-                        "  public static class EventNameEventResponse extends org.web3j.protocol.core.methods.response.BaseEventResponse {\n" +
-                        "    public java.lang.String action;\n" +
-                        "\n" +
-                        "    public java.lang.Boolean pauseState;\n" +
-                        "  }\n" +
-                        "\n" +
-                        "  public static class EventName1EventResponse extends org.web3j.protocol.core.methods.response.BaseEventResponse {\n" +
-                        "    public java.lang.String cToken;\n" +
-                        "\n" +
-                        "    public java.lang.String action;\n" +
-                        "\n" +
-                        "    public java.lang.Boolean pauseState;\n" +
-                        "  }\n" +
-                        "}\n";
+                "class testClass {\n"
+                        + "  public static final org.web3j.abi.datatypes.Event EVENTNAME_EVENT = new org.web3j.abi.datatypes.Event(\"eventName\", \n"
+                        + "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Utf8String>() {}, new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Bool>() {}));\n"
+                        + "  ;\n"
+                        + "\n"
+                        + "  public static final org.web3j.abi.datatypes.Event EVENTNAME1_EVENT = new org.web3j.abi.datatypes.Event(\"eventName1\", \n"
+                        + "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Address>() {}, new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Utf8String>() {}, new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Bool>() {}));\n"
+                        + "  ;\n"
+                        + "\n"
+                        + "  public static java.util.List<EventNameEventResponse> getEventNameEvents(org.web3j.protocol.core.methods.response.TransactionReceipt transactionReceipt) {\n"
+                        + "    java.util.List<org.web3j.tx.Contract.EventValuesWithLog> valueList = staticExtractEventParametersWithLog(EVENTNAME_EVENT, transactionReceipt);\n"
+                        + "    java.util.ArrayList<EventNameEventResponse> responses = new java.util.ArrayList<EventNameEventResponse>(valueList.size());\n"
+                        + "    for (org.web3j.tx.Contract.EventValuesWithLog eventValues : valueList) {\n"
+                        + "      EventNameEventResponse typedResponse = new EventNameEventResponse();\n"
+                        + "      typedResponse.log = eventValues.getLog();\n"
+                        + "      typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n"
+                        + "      typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(1).getValue();\n"
+                        + "      responses.add(typedResponse);\n"
+                        + "    }\n"
+                        + "    return responses;\n"
+                        + "  }\n"
+                        + "\n"
+                        + "  public io.reactivex.Flowable<EventNameEventResponse> eventNameEventFlowable(org.web3j.protocol.core.methods.request.EthFilter filter) {\n"
+                        + "    return web3j.ethLogFlowable(filter).map(new io.reactivex.functions.Function<org.web3j.protocol.core.methods.response.Log, EventNameEventResponse>() {\n"
+                        + "      @java.lang.Override\n"
+                        + "      public EventNameEventResponse apply(org.web3j.protocol.core.methods.response.Log log) {\n"
+                        + "        org.web3j.tx.Contract.EventValuesWithLog eventValues = extractEventParametersWithLog(EVENTNAME_EVENT, log);\n"
+                        + "        EventNameEventResponse typedResponse = new EventNameEventResponse();\n"
+                        + "        typedResponse.log = log;\n"
+                        + "        typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n"
+                        + "        typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(1).getValue();\n"
+                        + "        return typedResponse;\n"
+                        + "      }\n"
+                        + "    });\n"
+                        + "  }\n"
+                        + "\n"
+                        + "  public io.reactivex.Flowable<EventNameEventResponse> eventNameEventFlowable(org.web3j.protocol.core.DefaultBlockParameter startBlock, org.web3j.protocol.core.DefaultBlockParameter endBlock) {\n"
+                        + "    org.web3j.protocol.core.methods.request.EthFilter filter = new org.web3j.protocol.core.methods.request.EthFilter(startBlock, endBlock, getContractAddress());\n"
+                        + "    filter.addSingleTopic(org.web3j.abi.EventEncoder.encode(EVENTNAME_EVENT));\n"
+                        + "    return eventNameEventFlowable(filter);\n"
+                        + "  }\n"
+                        + "\n"
+                        + "  public static java.util.List<EventName1EventResponse> getEventName1Events(org.web3j.protocol.core.methods.response.TransactionReceipt transactionReceipt) {\n"
+                        + "    java.util.List<org.web3j.tx.Contract.EventValuesWithLog> valueList = staticExtractEventParametersWithLog(EVENTNAME1_EVENT, transactionReceipt);\n"
+                        + "    java.util.ArrayList<EventName1EventResponse> responses = new java.util.ArrayList<EventName1EventResponse>(valueList.size());\n"
+                        + "    for (org.web3j.tx.Contract.EventValuesWithLog eventValues : valueList) {\n"
+                        + "      EventName1EventResponse typedResponse = new EventName1EventResponse();\n"
+                        + "      typedResponse.log = eventValues.getLog();\n"
+                        + "      typedResponse.cToken = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n"
+                        + "      typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(1).getValue();\n"
+                        + "      typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(2).getValue();\n"
+                        + "      responses.add(typedResponse);\n"
+                        + "    }\n"
+                        + "    return responses;\n"
+                        + "  }\n"
+                        + "\n"
+                        + "  public io.reactivex.Flowable<EventName1EventResponse> eventName1EventFlowable(org.web3j.protocol.core.methods.request.EthFilter filter) {\n"
+                        + "    return web3j.ethLogFlowable(filter).map(new io.reactivex.functions.Function<org.web3j.protocol.core.methods.response.Log, EventName1EventResponse>() {\n"
+                        + "      @java.lang.Override\n"
+                        + "      public EventName1EventResponse apply(org.web3j.protocol.core.methods.response.Log log) {\n"
+                        + "        org.web3j.tx.Contract.EventValuesWithLog eventValues = extractEventParametersWithLog(EVENTNAME1_EVENT, log);\n"
+                        + "        EventName1EventResponse typedResponse = new EventName1EventResponse();\n"
+                        + "        typedResponse.log = log;\n"
+                        + "        typedResponse.cToken = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n"
+                        + "        typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(1).getValue();\n"
+                        + "        typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(2).getValue();\n"
+                        + "        return typedResponse;\n"
+                        + "      }\n"
+                        + "    });\n"
+                        + "  }\n"
+                        + "\n"
+                        + "  public io.reactivex.Flowable<EventName1EventResponse> eventName1EventFlowable(org.web3j.protocol.core.DefaultBlockParameter startBlock, org.web3j.protocol.core.DefaultBlockParameter endBlock) {\n"
+                        + "    org.web3j.protocol.core.methods.request.EthFilter filter = new org.web3j.protocol.core.methods.request.EthFilter(startBlock, endBlock, getContractAddress());\n"
+                        + "    filter.addSingleTopic(org.web3j.abi.EventEncoder.encode(EVENTNAME1_EVENT));\n"
+                        + "    return eventName1EventFlowable(filter);\n"
+                        + "  }\n"
+                        + "\n"
+                        + "  public static class EventNameEventResponse extends org.web3j.protocol.core.methods.response.BaseEventResponse {\n"
+                        + "    public java.lang.String action;\n"
+                        + "\n"
+                        + "    public java.lang.Boolean pauseState;\n"
+                        + "  }\n"
+                        + "\n"
+                        + "  public static class EventName1EventResponse extends org.web3j.protocol.core.methods.response.BaseEventResponse {\n"
+                        + "    public java.lang.String cToken;\n"
+                        + "\n"
+                        + "    public java.lang.String action;\n"
+                        + "\n"
+                        + "    public java.lang.Boolean pauseState;\n"
+                        + "  }\n"
+                        + "}\n";
 
         assertEquals(builder.build().toString(), (expected));
     }

--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -903,6 +903,124 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
     }
 
     @Test
+    public void testBuildFunctionDuplicatedEventNames() throws Exception {
+
+        AbiDefinition firstEventDefinition =
+                new AbiDefinition(
+                        false,
+                        Arrays.asList(new NamedType("action", "string", false), new NamedType("pauseState", "bool", false)),
+                        "eventName",
+                        Collections.emptyList(),
+                        "event",
+                        false);
+        AbiDefinition secondEventDefinition =
+                new AbiDefinition(
+                        false,
+                        Arrays.asList(new NamedType("cToken", "address", false), new NamedType("action", "string", false), new NamedType("pauseState", "bool", false)),
+                        "eventName",
+                        Collections.emptyList(),
+                        "event",
+                        false);
+        TypeSpec.Builder builder = TypeSpec.classBuilder("testClass");
+        builder.addMethods(solidityFunctionWrapper.buildFunctionDefinitions("testClass", builder, Arrays.asList(firstEventDefinition, secondEventDefinition)));
+
+        String expected =
+                "class testClass {\n" +
+                        "  public static final org.web3j.abi.datatypes.Event EVENTNAME_EVENT = new org.web3j.abi.datatypes.Event(\"eventName\", \n" +
+                        "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Utf8String>() {}, new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Bool>() {}));\n" +
+                        "  ;\n" +
+                        "\n" +
+                        "  public static final org.web3j.abi.datatypes.Event EVENTNAME1_EVENT = new org.web3j.abi.datatypes.Event(\"eventName1\", \n" +
+                        "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Address>() {}, new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Utf8String>() {}, new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Bool>() {}));\n" +
+                        "  ;\n" +
+                        "\n" +
+                        "  public static java.util.List<EventNameEventResponse> getEventNameEvents(org.web3j.protocol.core.methods.response.TransactionReceipt transactionReceipt) {\n" +
+                        "    java.util.List<org.web3j.tx.Contract.EventValuesWithLog> valueList = staticExtractEventParametersWithLog(EVENTNAME_EVENT, transactionReceipt);\n" +
+                        "    java.util.ArrayList<EventNameEventResponse> responses = new java.util.ArrayList<EventNameEventResponse>(valueList.size());\n" +
+                        "    for (org.web3j.tx.Contract.EventValuesWithLog eventValues : valueList) {\n" +
+                        "      EventNameEventResponse typedResponse = new EventNameEventResponse();\n" +
+                        "      typedResponse.log = eventValues.getLog();\n" +
+                        "      typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n" +
+                        "      typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(1).getValue();\n" +
+                        "      responses.add(typedResponse);\n" +
+                        "    }\n" +
+                        "    return responses;\n" +
+                        "  }\n" +
+                        "\n" +
+                        "  public io.reactivex.Flowable<EventNameEventResponse> eventNameEventFlowable(org.web3j.protocol.core.methods.request.EthFilter filter) {\n" +
+                        "    return web3j.ethLogFlowable(filter).map(new io.reactivex.functions.Function<org.web3j.protocol.core.methods.response.Log, EventNameEventResponse>() {\n" +
+                        "      @java.lang.Override\n" +
+                        "      public EventNameEventResponse apply(org.web3j.protocol.core.methods.response.Log log) {\n" +
+                        "        org.web3j.tx.Contract.EventValuesWithLog eventValues = extractEventParametersWithLog(EVENTNAME_EVENT, log);\n" +
+                        "        EventNameEventResponse typedResponse = new EventNameEventResponse();\n" +
+                        "        typedResponse.log = log;\n" +
+                        "        typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n" +
+                        "        typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(1).getValue();\n" +
+                        "        return typedResponse;\n" +
+                        "      }\n" +
+                        "    });\n" +
+                        "  }\n" +
+                        "\n" +
+                        "  public io.reactivex.Flowable<EventNameEventResponse> eventNameEventFlowable(org.web3j.protocol.core.DefaultBlockParameter startBlock, org.web3j.protocol.core.DefaultBlockParameter endBlock) {\n" +
+                        "    org.web3j.protocol.core.methods.request.EthFilter filter = new org.web3j.protocol.core.methods.request.EthFilter(startBlock, endBlock, getContractAddress());\n" +
+                        "    filter.addSingleTopic(org.web3j.abi.EventEncoder.encode(EVENTNAME_EVENT));\n" +
+                        "    return eventNameEventFlowable(filter);\n" +
+                        "  }\n" +
+                        "\n" +
+                        "  public static java.util.List<EventName1EventResponse> getEventName1Events(org.web3j.protocol.core.methods.response.TransactionReceipt transactionReceipt) {\n" +
+                        "    java.util.List<org.web3j.tx.Contract.EventValuesWithLog> valueList = staticExtractEventParametersWithLog(EVENTNAME1_EVENT, transactionReceipt);\n" +
+                        "    java.util.ArrayList<EventName1EventResponse> responses = new java.util.ArrayList<EventName1EventResponse>(valueList.size());\n" +
+                        "    for (org.web3j.tx.Contract.EventValuesWithLog eventValues : valueList) {\n" +
+                        "      EventName1EventResponse typedResponse = new EventName1EventResponse();\n" +
+                        "      typedResponse.log = eventValues.getLog();\n" +
+                        "      typedResponse.cToken = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n" +
+                        "      typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(1).getValue();\n" +
+                        "      typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(2).getValue();\n" +
+                        "      responses.add(typedResponse);\n" +
+                        "    }\n" +
+                        "    return responses;\n" +
+                        "  }\n" +
+                        "\n" +
+                        "  public io.reactivex.Flowable<EventName1EventResponse> eventName1EventFlowable(org.web3j.protocol.core.methods.request.EthFilter filter) {\n" +
+                        "    return web3j.ethLogFlowable(filter).map(new io.reactivex.functions.Function<org.web3j.protocol.core.methods.response.Log, EventName1EventResponse>() {\n" +
+                        "      @java.lang.Override\n" +
+                        "      public EventName1EventResponse apply(org.web3j.protocol.core.methods.response.Log log) {\n" +
+                        "        org.web3j.tx.Contract.EventValuesWithLog eventValues = extractEventParametersWithLog(EVENTNAME1_EVENT, log);\n" +
+                        "        EventName1EventResponse typedResponse = new EventName1EventResponse();\n" +
+                        "        typedResponse.log = log;\n" +
+                        "        typedResponse.cToken = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n" +
+                        "        typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(1).getValue();\n" +
+                        "        typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(2).getValue();\n" +
+                        "        return typedResponse;\n" +
+                        "      }\n" +
+                        "    });\n" +
+                        "  }\n" +
+                        "\n" +
+                        "  public io.reactivex.Flowable<EventName1EventResponse> eventName1EventFlowable(org.web3j.protocol.core.DefaultBlockParameter startBlock, org.web3j.protocol.core.DefaultBlockParameter endBlock) {\n" +
+                        "    org.web3j.protocol.core.methods.request.EthFilter filter = new org.web3j.protocol.core.methods.request.EthFilter(startBlock, endBlock, getContractAddress());\n" +
+                        "    filter.addSingleTopic(org.web3j.abi.EventEncoder.encode(EVENTNAME1_EVENT));\n" +
+                        "    return eventName1EventFlowable(filter);\n" +
+                        "  }\n" +
+                        "\n" +
+                        "  public static class EventNameEventResponse extends org.web3j.protocol.core.methods.response.BaseEventResponse {\n" +
+                        "    public java.lang.String action;\n" +
+                        "\n" +
+                        "    public java.lang.Boolean pauseState;\n" +
+                        "  }\n" +
+                        "\n" +
+                        "  public static class EventName1EventResponse extends org.web3j.protocol.core.methods.response.BaseEventResponse {\n" +
+                        "    public java.lang.String cToken;\n" +
+                        "\n" +
+                        "    public java.lang.String action;\n" +
+                        "\n" +
+                        "    public java.lang.Boolean pauseState;\n" +
+                        "  }\n" +
+                        "}\n";
+
+        assertEquals(builder.build().toString(), (expected));
+    }
+
+    @Test
     public void testBuildFunctionTransactionAndCall() throws Exception {
         AbiDefinition functionDefinition =
                 new AbiDefinition(

--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -673,7 +673,11 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         TypeSpec.Builder builder = TypeSpec.classBuilder("testClass");
 
         builder.addMethods(
-                solidityFunctionWrapper.buildEventFunctions(functionDefinition, builder));
+                solidityFunctionWrapper.buildEventFunctions(
+                        functionDefinition,
+                        builder,
+                        solidityFunctionWrapper.getDuplicatedEventNames(
+                                Collections.singletonList(functionDefinition))));
 
         String expected =
                 "class testClass {\n"
@@ -757,7 +761,11 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         TypeSpec.Builder builder = TypeSpec.classBuilder("testClass");
 
         builder.addMethods(
-                solidityFunctionWrapper.buildEventFunctions(functionDefinition, builder));
+                solidityFunctionWrapper.buildEventFunctions(
+                        functionDefinition,
+                        builder,
+                        solidityFunctionWrapper.getDuplicatedEventNames(
+                                Collections.singletonList(functionDefinition))));
 
         String expected =
                 "class testClass {\n"
@@ -833,7 +841,11 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         TypeSpec.Builder builder = TypeSpec.classBuilder("testClass");
 
         builder.addMethods(
-                solidityFunctionWrapper.buildEventFunctions(functionDefinition, builder));
+                solidityFunctionWrapper.buildEventFunctions(
+                        functionDefinition,
+                        builder,
+                        solidityFunctionWrapper.getDuplicatedEventNames(
+                                Collections.singletonList(functionDefinition))));
 
         String expected =
                 "class testClass {\n"
@@ -935,13 +947,46 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
 
         String expected =
                 "class testClass {\n"
-                        + "  public static final org.web3j.abi.datatypes.Event EVENTNAME_EVENT = new org.web3j.abi.datatypes.Event(\"eventName\", \n"
+                        + "  public static final org.web3j.abi.datatypes.Event EVENTNAME1_EVENT = new org.web3j.abi.datatypes.Event(\"eventName\", \n"
                         + "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Utf8String>() {}, new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Bool>() {}));\n"
                         + "  ;\n"
                         + "\n"
-                        + "  public static final org.web3j.abi.datatypes.Event EVENTNAME1_EVENT = new org.web3j.abi.datatypes.Event(\"eventName1\", \n"
+                        + "  public static final org.web3j.abi.datatypes.Event EVENTNAME_EVENT = new org.web3j.abi.datatypes.Event(\"eventName\", \n"
                         + "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Address>() {}, new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Utf8String>() {}, new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Bool>() {}));\n"
                         + "  ;\n"
+                        + "\n"
+                        + "  public static java.util.List<EventNameEventResponse> getEventName1Events(org.web3j.protocol.core.methods.response.TransactionReceipt transactionReceipt) {\n"
+                        + "    java.util.List<org.web3j.tx.Contract.EventValuesWithLog> valueList = staticExtractEventParametersWithLog(EVENTNAME1_EVENT, transactionReceipt);\n"
+                        + "    java.util.ArrayList<EventNameEventResponse> responses = new java.util.ArrayList<EventNameEventResponse>(valueList.size());\n"
+                        + "    for (org.web3j.tx.Contract.EventValuesWithLog eventValues : valueList) {\n"
+                        + "      EventNameEventResponse typedResponse = new EventNameEventResponse();\n"
+                        + "      typedResponse.log = eventValues.getLog();\n"
+                        + "      typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n"
+                        + "      typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(1).getValue();\n"
+                        + "      responses.add(typedResponse);\n"
+                        + "    }\n"
+                        + "    return responses;\n"
+                        + "  }\n"
+                        + "\n"
+                        + "  public io.reactivex.Flowable<EventNameEventResponse> eventName1EventFlowable(org.web3j.protocol.core.methods.request.EthFilter filter) {\n"
+                        + "    return web3j.ethLogFlowable(filter).map(new io.reactivex.functions.Function<org.web3j.protocol.core.methods.response.Log, EventNameEventResponse>() {\n"
+                        + "      @java.lang.Override\n"
+                        + "      public EventNameEventResponse apply(org.web3j.protocol.core.methods.response.Log log) {\n"
+                        + "        org.web3j.tx.Contract.EventValuesWithLog eventValues = extractEventParametersWithLog(EVENTNAME1_EVENT, log);\n"
+                        + "        EventNameEventResponse typedResponse = new EventNameEventResponse();\n"
+                        + "        typedResponse.log = log;\n"
+                        + "        typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n"
+                        + "        typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(1).getValue();\n"
+                        + "        return typedResponse;\n"
+                        + "      }\n"
+                        + "    });\n"
+                        + "  }\n"
+                        + "\n"
+                        + "  public io.reactivex.Flowable<EventNameEventResponse> eventName1EventFlowable(org.web3j.protocol.core.DefaultBlockParameter startBlock, org.web3j.protocol.core.DefaultBlockParameter endBlock) {\n"
+                        + "    org.web3j.protocol.core.methods.request.EthFilter filter = new org.web3j.protocol.core.methods.request.EthFilter(startBlock, endBlock, getContractAddress());\n"
+                        + "    filter.addSingleTopic(org.web3j.abi.EventEncoder.encode(EVENTNAME1_EVENT));\n"
+                        + "    return eventName1EventFlowable(filter);\n"
+                        + "  }\n"
                         + "\n"
                         + "  public static java.util.List<EventNameEventResponse> getEventNameEvents(org.web3j.protocol.core.methods.response.TransactionReceipt transactionReceipt) {\n"
                         + "    java.util.List<org.web3j.tx.Contract.EventValuesWithLog> valueList = staticExtractEventParametersWithLog(EVENTNAME_EVENT, transactionReceipt);\n"
@@ -949,8 +994,9 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
                         + "    for (org.web3j.tx.Contract.EventValuesWithLog eventValues : valueList) {\n"
                         + "      EventNameEventResponse typedResponse = new EventNameEventResponse();\n"
                         + "      typedResponse.log = eventValues.getLog();\n"
-                        + "      typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n"
-                        + "      typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(1).getValue();\n"
+                        + "      typedResponse.cToken = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n"
+                        + "      typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(1).getValue();\n"
+                        + "      typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(2).getValue();\n"
                         + "      responses.add(typedResponse);\n"
                         + "    }\n"
                         + "    return responses;\n"
@@ -963,8 +1009,9 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
                         + "        org.web3j.tx.Contract.EventValuesWithLog eventValues = extractEventParametersWithLog(EVENTNAME_EVENT, log);\n"
                         + "        EventNameEventResponse typedResponse = new EventNameEventResponse();\n"
                         + "        typedResponse.log = log;\n"
-                        + "        typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n"
-                        + "        typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(1).getValue();\n"
+                        + "        typedResponse.cToken = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n"
+                        + "        typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(1).getValue();\n"
+                        + "        typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(2).getValue();\n"
                         + "        return typedResponse;\n"
                         + "      }\n"
                         + "    });\n"
@@ -976,48 +1023,13 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
                         + "    return eventNameEventFlowable(filter);\n"
                         + "  }\n"
                         + "\n"
-                        + "  public static java.util.List<EventName1EventResponse> getEventName1Events(org.web3j.protocol.core.methods.response.TransactionReceipt transactionReceipt) {\n"
-                        + "    java.util.List<org.web3j.tx.Contract.EventValuesWithLog> valueList = staticExtractEventParametersWithLog(EVENTNAME1_EVENT, transactionReceipt);\n"
-                        + "    java.util.ArrayList<EventName1EventResponse> responses = new java.util.ArrayList<EventName1EventResponse>(valueList.size());\n"
-                        + "    for (org.web3j.tx.Contract.EventValuesWithLog eventValues : valueList) {\n"
-                        + "      EventName1EventResponse typedResponse = new EventName1EventResponse();\n"
-                        + "      typedResponse.log = eventValues.getLog();\n"
-                        + "      typedResponse.cToken = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n"
-                        + "      typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(1).getValue();\n"
-                        + "      typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(2).getValue();\n"
-                        + "      responses.add(typedResponse);\n"
-                        + "    }\n"
-                        + "    return responses;\n"
-                        + "  }\n"
-                        + "\n"
-                        + "  public io.reactivex.Flowable<EventName1EventResponse> eventName1EventFlowable(org.web3j.protocol.core.methods.request.EthFilter filter) {\n"
-                        + "    return web3j.ethLogFlowable(filter).map(new io.reactivex.functions.Function<org.web3j.protocol.core.methods.response.Log, EventName1EventResponse>() {\n"
-                        + "      @java.lang.Override\n"
-                        + "      public EventName1EventResponse apply(org.web3j.protocol.core.methods.response.Log log) {\n"
-                        + "        org.web3j.tx.Contract.EventValuesWithLog eventValues = extractEventParametersWithLog(EVENTNAME1_EVENT, log);\n"
-                        + "        EventName1EventResponse typedResponse = new EventName1EventResponse();\n"
-                        + "        typedResponse.log = log;\n"
-                        + "        typedResponse.cToken = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n"
-                        + "        typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(1).getValue();\n"
-                        + "        typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(2).getValue();\n"
-                        + "        return typedResponse;\n"
-                        + "      }\n"
-                        + "    });\n"
-                        + "  }\n"
-                        + "\n"
-                        + "  public io.reactivex.Flowable<EventName1EventResponse> eventName1EventFlowable(org.web3j.protocol.core.DefaultBlockParameter startBlock, org.web3j.protocol.core.DefaultBlockParameter endBlock) {\n"
-                        + "    org.web3j.protocol.core.methods.request.EthFilter filter = new org.web3j.protocol.core.methods.request.EthFilter(startBlock, endBlock, getContractAddress());\n"
-                        + "    filter.addSingleTopic(org.web3j.abi.EventEncoder.encode(EVENTNAME1_EVENT));\n"
-                        + "    return eventName1EventFlowable(filter);\n"
-                        + "  }\n"
-                        + "\n"
                         + "  public static class EventNameEventResponse extends org.web3j.protocol.core.methods.response.BaseEventResponse {\n"
                         + "    public java.lang.String action;\n"
                         + "\n"
                         + "    public java.lang.Boolean pauseState;\n"
                         + "  }\n"
                         + "\n"
-                        + "  public static class EventName1EventResponse extends org.web3j.protocol.core.methods.response.BaseEventResponse {\n"
+                        + "  public static class EventNameEventResponse extends org.web3j.protocol.core.methods.response.BaseEventResponse {\n"
                         + "    public java.lang.String cToken;\n"
                         + "\n"
                         + "    public java.lang.String action;\n"


### PR DESCRIPTION
### What does this PR do?
Add a condition on the name of the events of the java wrapper

### Where should the reviewer start?
There is just a one file.

### Why is it needed?
Based on Issue #1781, for contracts which have '**overloaded**' events (same name, but different signatures) the Java Wrapper creates those events as different instances of the Event class, but with the same variable name, thus resulting in an error. This PR adds the `changeEventsName()` method which uses an HashMap to count the occurences of an event name, and for those with more than one occurence, it will change the name putting a number at its end, e.g. 

```
public static final Event ACTIONPAUSED_EVENT = new Event("ActionPaused",
            Arrays.<TypeReference<?>>asList(new TypeReference<Utf8String>() {}, new TypeReference<Bool>() {}));
    ;

    public static final Event ACTIONPAUSED1_EVENT = new Event("ActionPaused", 
            Arrays.<TypeReference<?>>asList(new TypeReference<Address>() {}, new TypeReference<Utf8String>() {}, new TypeReference<Bool>() {}));
    ;
```