### PR TITLE
Introducing Web3j Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Web3j: Web3 Java Ethereum Ðapp API
 [![build status](https://github.com/web3j/web3j/actions/workflows/build.yml/badge.svg)](https://github.com/web3j/web3j/actions/workflows/build.yml)
 [![codecov](https://codecov.io/gh/web3j/web3j/branch/main/graph/badge.svg?token=a4G9ITI6CU)](https://codecov.io/gh/web3j/web3j)
 [![Discord](https://img.shields.io/discord/779382027614158919?label=discord)](https://discord.gg/A9UXfPF2tS)
-
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Web3j%20Guru-006BFF)](https://gurubase.io/g/web3j)
 
 
 Web3j is a lightweight, highly modular, reactive, type safe Java and


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Web3j Guru](https://gurubase.io/g/web3j) to Gurubase. Web3j Guru uses the data from this repo and data from the [docs](https://docs.web3j.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "Web3j Guru", which highlights that Web3j now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Web3j Guru in Gurubase, just let me know that's totally fine.
