### PR TITLE
Counter on duplicated event names

### DIFF
--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -685,7 +685,11 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         TypeSpec.Builder builder = TypeSpec.classBuilder("testClass");
 
         builder.addMethods(
-                solidityFunctionWrapper.buildEventFunctions(functionDefinition, builder));
+                solidityFunctionWrapper.buildEventFunctions(
+                        functionDefinition,
+                        builder,
+                        solidityFunctionWrapper.getDuplicatedEventNames(
+                                Collections.singletonList(functionDefinition))));
 
         String expected =
                 "class testClass {\n"
@@ -773,7 +777,11 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         TypeSpec.Builder builder = TypeSpec.classBuilder("testClass");
 
         builder.addMethods(
-                solidityFunctionWrapper.buildEventFunctions(functionDefinition, builder));
+                solidityFunctionWrapper.buildEventFunctions(
+                        functionDefinition,
+                        builder,
+                        solidityFunctionWrapper.getDuplicatedEventNames(
+                                Collections.singletonList(functionDefinition))));
 
         String expected =
                 "class testClass {\n"
@@ -853,7 +861,11 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         TypeSpec.Builder builder = TypeSpec.classBuilder("testClass");
 
         builder.addMethods(
-                solidityFunctionWrapper.buildEventFunctions(functionDefinition, builder));
+                solidityFunctionWrapper.buildEventFunctions(
+                        functionDefinition,
+                        builder,
+                        solidityFunctionWrapper.getDuplicatedEventNames(
+                                Collections.singletonList(functionDefinition))));
 
         String expected =
                 "class testClass {\n"
@@ -922,6 +934,140 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
                 "class testClass {\n"
                         + "  public static final java.lang.String FUNC_FUNCTIONNAME = \"functionName\";\n"
                         + "}\n";
+
+        assertEquals(builder.build().toString(), (expected));
+    }
+
+    @Test
+    public void testBuildFunctionDuplicatedEventNames() throws Exception {
+        AbiDefinition firstEventDefinition =
+                new AbiDefinition(
+                        false,
+                        Arrays.asList(
+                                new NamedType("action", "string", false),
+                                new NamedType("pauseState", "bool", false)),
+                        "eventName",
+                        Collections.emptyList(),
+                        "event",
+                        false);
+        AbiDefinition secondEventDefinition =
+                new AbiDefinition(
+                        false,
+                        Arrays.asList(
+                                new NamedType("cToken", "address", false),
+                                new NamedType("action", "string", false),
+                                new NamedType("pauseState", "bool", false)),
+                        "eventName",
+                        Collections.emptyList(),
+                        "event",
+                        false);
+        TypeSpec.Builder builder = TypeSpec.classBuilder("testClass");
+        builder.addMethods(
+                solidityFunctionWrapper.buildFunctionDefinitions(
+                        "testClass",
+                        builder,
+                        Arrays.asList(firstEventDefinition, secondEventDefinition)));
+
+        String expected =
+                "class testClass {\n" +
+                        "  public static final org.web3j.abi.datatypes.Event EVENTNAME1_EVENT = new org.web3j.abi.datatypes.Event(\"eventName\", \n" +
+                        "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Utf8String>() {}, new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Bool>() {}));\n" +
+                        "  ;\n" +
+                        "\n" +
+                        "  public static final org.web3j.abi.datatypes.Event EVENTNAME_EVENT = new org.web3j.abi.datatypes.Event(\"eventName\", \n" +
+                        "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Address>() {}, new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Utf8String>() {}, new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.Bool>() {}));\n" +
+                        "  ;\n" +
+                        "\n" +
+                        "  public static java.util.List<EventName1EventResponse> getEventName1Events(\n" +
+                        "      org.web3j.protocol.core.methods.response.TransactionReceipt transactionReceipt) {\n" +
+                        "    java.util.List<org.web3j.tx.Contract.EventValuesWithLog> valueList = staticExtractEventParametersWithLog(EVENTNAME1_EVENT, transactionReceipt);\n" +
+                        "    java.util.ArrayList<EventName1EventResponse> responses = new java.util.ArrayList<EventName1EventResponse>(valueList.size());\n" +
+                        "    for (org.web3j.tx.Contract.EventValuesWithLog eventValues : valueList) {\n" +
+                        "      EventName1EventResponse typedResponse = new EventName1EventResponse();\n" +
+                        "      typedResponse.log = eventValues.getLog();\n" +
+                        "      typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n" +
+                        "      typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(1).getValue();\n" +
+                        "      responses.add(typedResponse);\n" +
+                        "    }\n" +
+                        "    return responses;\n" +
+                        "  }\n" +
+                        "\n" +
+                        "  public static EventName1EventResponse getEventName1EventFromLog(\n" +
+                        "      org.web3j.protocol.core.methods.response.Log log) {\n" +
+                        "    org.web3j.tx.Contract.EventValuesWithLog eventValues = staticExtractEventParametersWithLog(EVENTNAME1_EVENT, log);\n" +
+                        "    EventName1EventResponse typedResponse = new EventName1EventResponse();\n" +
+                        "    typedResponse.log = log;\n" +
+                        "    typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n" +
+                        "    typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(1).getValue();\n" +
+                        "    return typedResponse;\n" +
+                        "  }\n" +
+                        "\n" +
+                        "  public io.reactivex.Flowable<EventName1EventResponse> eventName1EventFlowable(\n" +
+                        "      org.web3j.protocol.core.methods.request.EthFilter filter) {\n" +
+                        "    return web3j.ethLogFlowable(filter).map(log -> getEventName1EventFromLog(log));\n" +
+                        "  }\n" +
+                        "\n" +
+                        "  public io.reactivex.Flowable<EventName1EventResponse> eventName1EventFlowable(\n" +
+                        "      org.web3j.protocol.core.DefaultBlockParameter startBlock,\n" +
+                        "      org.web3j.protocol.core.DefaultBlockParameter endBlock) {\n" +
+                        "    org.web3j.protocol.core.methods.request.EthFilter filter = new org.web3j.protocol.core.methods.request.EthFilter(startBlock, endBlock, getContractAddress());\n" +
+                        "    filter.addSingleTopic(org.web3j.abi.EventEncoder.encode(EVENTNAME1_EVENT));\n" +
+                        "    return eventName1EventFlowable(filter);\n" +
+                        "  }\n" +
+                        "\n" +
+                        "  public static java.util.List<EventNameEventResponse> getEventNameEvents(\n" +
+                        "      org.web3j.protocol.core.methods.response.TransactionReceipt transactionReceipt) {\n" +
+                        "    java.util.List<org.web3j.tx.Contract.EventValuesWithLog> valueList = staticExtractEventParametersWithLog(EVENTNAME_EVENT, transactionReceipt);\n" +
+                        "    java.util.ArrayList<EventNameEventResponse> responses = new java.util.ArrayList<EventNameEventResponse>(valueList.size());\n" +
+                        "    for (org.web3j.tx.Contract.EventValuesWithLog eventValues : valueList) {\n" +
+                        "      EventNameEventResponse typedResponse = new EventNameEventResponse();\n" +
+                        "      typedResponse.log = eventValues.getLog();\n" +
+                        "      typedResponse.cToken = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n" +
+                        "      typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(1).getValue();\n" +
+                        "      typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(2).getValue();\n" +
+                        "      responses.add(typedResponse);\n" +
+                        "    }\n" +
+                        "    return responses;\n" +
+                        "  }\n" +
+                        "\n" +
+                        "  public static EventNameEventResponse getEventNameEventFromLog(\n" +
+                        "      org.web3j.protocol.core.methods.response.Log log) {\n" +
+                        "    org.web3j.tx.Contract.EventValuesWithLog eventValues = staticExtractEventParametersWithLog(EVENTNAME_EVENT, log);\n" +
+                        "    EventNameEventResponse typedResponse = new EventNameEventResponse();\n" +
+                        "    typedResponse.log = log;\n" +
+                        "    typedResponse.cToken = (java.lang.String) eventValues.getNonIndexedValues().get(0).getValue();\n" +
+                        "    typedResponse.action = (java.lang.String) eventValues.getNonIndexedValues().get(1).getValue();\n" +
+                        "    typedResponse.pauseState = (java.lang.Boolean) eventValues.getNonIndexedValues().get(2).getValue();\n" +
+                        "    return typedResponse;\n" +
+                        "  }\n" +
+                        "\n" +
+                        "  public io.reactivex.Flowable<EventNameEventResponse> eventNameEventFlowable(\n" +
+                        "      org.web3j.protocol.core.methods.request.EthFilter filter) {\n" +
+                        "    return web3j.ethLogFlowable(filter).map(log -> getEventNameEventFromLog(log));\n" +
+                        "  }\n" +
+                        "\n" +
+                        "  public io.reactivex.Flowable<EventNameEventResponse> eventNameEventFlowable(\n" +
+                        "      org.web3j.protocol.core.DefaultBlockParameter startBlock,\n" +
+                        "      org.web3j.protocol.core.DefaultBlockParameter endBlock) {\n" +
+                        "    org.web3j.protocol.core.methods.request.EthFilter filter = new org.web3j.protocol.core.methods.request.EthFilter(startBlock, endBlock, getContractAddress());\n" +
+                        "    filter.addSingleTopic(org.web3j.abi.EventEncoder.encode(EVENTNAME_EVENT));\n" +
+                        "    return eventNameEventFlowable(filter);\n" +
+                        "  }\n" +
+                        "\n" +
+                        "  public static class EventName1EventResponse extends org.web3j.protocol.core.methods.response.BaseEventResponse {\n" +
+                        "    public java.lang.String action;\n" +
+                        "\n" +
+                        "    public java.lang.Boolean pauseState;\n" +
+                        "  }\n" +
+                        "\n" +
+                        "  public static class EventNameEventResponse extends org.web3j.protocol.core.methods.response.BaseEventResponse {\n" +
+                        "    public java.lang.String cToken;\n" +
+                        "\n" +
+                        "    public java.lang.String action;\n" +
+                        "\n" +
+                        "    public java.lang.Boolean pauseState;\n" +
+                        "  }\n" +
+                        "}\n";
 
         assertEquals(builder.build().toString(), (expected));
     }


### PR DESCRIPTION
### What does this PR do?
Fix for when more than 1 event with the same name but different signature is found in a contract

This PR is a continuation of https://github.com/hyperledger-web3j/web3j/pull/1872 testing and fixing that the event corresponds to the function in buildEventFunctions

### Where should the reviewer start?
It is a simple PR, it only has a modified file and the corresponding test

### Why is it needed?
Same reasons as https://github.com/hyperledger-web3j/web3j/pull/1872
Relative to issue https://github.com/hyperledger-web3j/web3j/issues/1781
