### PR TITLE
#2121 - clear subscriptionForId map after websocket disconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * fixed several code issues found by sonar [#2113](https://github.com/hyperledger/web3j/pull/2113)
 * update GitHub actions versions [#2114](https://github.com/hyperledger/web3j/pull/2114)
+* fixed subscription object leaking after disconnect [#2121](https://github.com/hyperledger/web3j/pull/2121)
 
 ### Features
 

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketService.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketService.java
@@ -557,6 +557,7 @@ public class WebSocketService implements Web3jService {
                                 request.getOnReply()
                                         .completeExceptionally(
                                                 new IOException("Connection was closed")));
+        requestForId.clear();
     }
 
     private void closeOutstandingSubscriptions() {
@@ -567,6 +568,7 @@ public class WebSocketService implements Web3jService {
                                 subscription
                                         .getSubject()
                                         .onError(new IOException("Connection was closed")));
+        subscriptionForId.clear();
     }
 
     // Method visible for unit-tests


### PR DESCRIPTION
### What does this PR do?
fixes #2121

### Where should the reviewer start?
At WebSocketService.java

### Why is it needed?
to fix #2121

## Checklist

- [X] I've read the contribution guidelines.
- [ ] I've added tests (if applicable).
- [X] I've added a changelog entry if necessary.