### PR TITLE
fix Transaction.getChainId when v=27 must return null

### DIFF
--- a/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
@@ -1181,6 +1181,21 @@ class ResponseTest extends ResponseTester {
         Transaction transaction = new Transaction();
         transaction.setV(0x25);
         assertEquals(transaction.getChainId(), (1L));
+
+        Transaction transaction2 = new Transaction();
+        transaction2.setV(0x24);
+        assertEquals(transaction2.getChainId(), (0L));
+    }
+
+    @Test
+    void testTransactionWithoutChainId() {
+        Transaction transaction1 = new Transaction();
+        transaction1.setV(0x1b); // 27
+        assertEquals(transaction1.getChainId(), null);
+
+        Transaction transaction2 = new Transaction();
+        transaction2.setV(0x1c); // 28
+        assertEquals(transaction2.getChainId(), null);
     }
 
     @Test

--- a/crypto/src/main/java/org/web3j/crypto/TransactionUtils.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionUtils.java
@@ -77,9 +77,9 @@ public class TransactionUtils {
      * @param v recovery identifier
      * @return Chain id
      */
-    public static long deriveChainId(long v) {
+    public static Long deriveChainId(long v) {
         if (v == LOWER_REAL_V || v == (LOWER_REAL_V + 1)) {
-            return 0L;
+            return null;
         }
         return (v - CHAIN_ID_INC) / 2;
     }

--- a/crypto/src/test/java/org/web3j/crypto/TransactionUtilsTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionUtilsTest.java
@@ -15,6 +15,7 @@ package org.web3j.crypto;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.web3j.crypto.TransactionUtils.generateTransactionHashHexEncoded;
 
 public class TransactionUtilsTest {
@@ -60,10 +61,10 @@ public class TransactionUtilsTest {
         long v1 = 27;
         long v2 = 28;
 
-        long chainId_1 = TransactionUtils.deriveChainId(v1);
-        long chainId_2 = TransactionUtils.deriveChainId(v2);
+        Long chainId_1 = TransactionUtils.deriveChainId(v1);
+        Long chainId_2 = TransactionUtils.deriveChainId(v2);
 
-        assertEquals(0, chainId_1);
-        assertEquals(0, chainId_2);
+        assertNull(chainId_1);
+        assertNull(chainId_2);
     }
 }


### PR DESCRIPTION
### What does this PR do?
fix `deriveChainId(long v)`, when `v=27` or `v=28` must return null instead of `0`, as per [EIP155](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#specification) 

### Where should the reviewer start?
crypto/src/main/java/org/web3j/crypto/TransactionUtils.java#deriveChainId

### Why is it needed?
The current seems to be buggy and comply with the EIP155 spec

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [ ] I've added a changelog entry if necessary.