### PR TITLE
Label Hash function added

### DIFF
--- a/core/src/main/java/org/web3j/ens/NameHash.java
+++ b/core/src/main/java/org/web3j/ens/NameHash.java
@@ -107,4 +107,17 @@ public class NameHash {
 
         return Numeric.toHexString(outputStream.toByteArray()) + "00";
     }
+
+    public static String labelHash(String ensName) {
+        if (ensName.isEmpty()) {
+            return Numeric.toHexString(EMPTY);
+        } else {
+            String normalisedEnsName = normalise(ensName);
+            return Numeric.toHexString(Hash.sha3(normalisedEnsName.split("\\.")[0].getBytes(StandardCharsets.UTF_8)));
+        }
+    }
+
+    public static byte[] labelHashAsBytes(String ensName) {
+        return Numeric.hexStringToByteArray(labelHash(ensName));
+    }
 }

--- a/core/src/test/java/org/web3j/ens/NameHashTest.java
+++ b/core/src/test/java/org/web3j/ens/NameHashTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.web3j.ens.NameHash.labelHash;
 import static org.web3j.ens.NameHash.nameHash;
 import static org.web3j.ens.NameHash.normalise;
 
@@ -40,6 +41,25 @@ class NameHashTest {
         assertEquals(
                 nameHash("\uD83D\uDC8E.gmcafe.art"),
                 ("0xf7de5954cda078ee481b14cff677e8066fe805a89b5c87b4a9b866338049b04a"));
+    }
+
+    @Test
+    void testLabelHash() {
+        assertEquals(
+                labelHash(""),
+                ("0x0000000000000000000000000000000000000000000000000000000000000000"));
+
+        assertEquals(
+                labelHash("label"),
+                ("0x1b036544434cea9770a413fd03e0fb240e1ccbd10a452f7dba85c8eca9ca3eda"));
+
+        assertEquals(
+                labelHash("label.eth"),
+                ("0x1b036544434cea9770a413fd03e0fb240e1ccbd10a452f7dba85c8eca9ca3eda"));
+
+        assertEquals(
+                labelHash("\uD83D\uDC8E.gmcafe.art"),
+                ("0xed2cc33b0587afe42a04579d79c23b72b25c5416efcb50c674f3f59e2db9cce6"));
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
Adds fucntionality to calculate Label Hash of any ENS name

### Where should the reviewer start?
review all

### Why is it needed?
Current NameHash function gives wrong labelHash values. It fixes that issue

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [ ] I've added a changelog entry if necessary.